### PR TITLE
fix github protocol drop

### DIFF
--- a/luagcrypt-0.2-1.rockspec
+++ b/luagcrypt-0.2-1.rockspec
@@ -2,7 +2,7 @@ package = "luagcrypt"
 version = "0.2-1"
 
 source = {
-  url = "https://github.com/Lekensteyn/luagcrypt.git",
+  url = "git+http://github.com/Lekensteyn/luagcrypt.git",
   tag = "v0.2",
 }
 

--- a/luagcrypt-0.2-1.rockspec
+++ b/luagcrypt-0.2-1.rockspec
@@ -2,7 +2,7 @@ package = "luagcrypt"
 version = "0.2-1"
 
 source = {
-  url = "git://github.com/Lekensteyn/luagcrypt.git",
+  url = "https://github.com/Lekensteyn/luagcrypt.git",
   tag = "v0.2",
 }
 


### PR DESCRIPTION
lease see https://github.blog/2021-09-01-improving-git-protocol-security-github/

from 11 of january, github drop git:// protocol for un-autenticated users (most automated installs off the lib)